### PR TITLE
Fix return document's title

### DIFF
--- a/returndocument.html
+++ b/returndocument.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>{%Receipt} {OrderNumber}</title>
+<title>{%ReturnDocument} {OrderNumber}</title>
 
 <link rel="stylesheet" type="text/css" href="{ThemeUrl}/css/printables.css?date=20210304" />
 


### PR DESCRIPTION
Title was incorrectly saying that it was a receipt. The incorrect title did not reflect into the content of created PDF.