### PR TITLE
MCP-518 Add limitation for logo image size in default print templates

### DIFF
--- a/addresslabel.html
+++ b/addresslabel.html
@@ -67,7 +67,7 @@
 	</style>
 </head>
 <body>
-	{Logo}
+	{Logo(height: '100px')}
 	<div class="Content">
 		<div class="Receiver">
 		<p>

--- a/addresslabel.html
+++ b/addresslabel.html
@@ -67,7 +67,7 @@
 	</style>
 </head>
 <body>
-	{Logo(height: '100px')}
+	{Logo(height: '100')}
 	<div class="Content">
 		<div class="Receiver">
 		<p>

--- a/dispatchnote.html
+++ b/dispatchnote.html
@@ -12,7 +12,7 @@
 
 	<div id="ReceiptHeader">
 		<div id="Logo">
-			{Logo}
+			{Logo(height: '100px')}
 		</div>
 		<div id="ReceiptTitle">
 			<h4>{ShopName}</h4>

--- a/dispatchnote.html
+++ b/dispatchnote.html
@@ -12,7 +12,7 @@
 
 	<div id="ReceiptHeader">
 		<div id="Logo">
-			{Logo(height: '100px')}
+			{Logo(height: '100')}
 		</div>
 		<div id="ReceiptTitle">
 			<h4>{ShopName}</h4>

--- a/invoice.html
+++ b/invoice.html
@@ -12,7 +12,7 @@
 
 	<div id="ReceiptHeader">
 		<div id="Logo">
-			{Logo}
+			{Logo(height: '100px')}
 		</div>
 		<div id="ReceiptTitle">
 			<h4>{ShopName}</h4>

--- a/invoice.html
+++ b/invoice.html
@@ -12,7 +12,7 @@
 
 	<div id="ReceiptHeader">
 		<div id="Logo">
-			{Logo(height: '100px')}
+			{Logo(height: '100')}
 		</div>
 		<div id="ReceiptTitle">
 			<h4>{ShopName}</h4>

--- a/pos-receipt.html
+++ b/pos-receipt.html
@@ -8,7 +8,7 @@
 	<body>
 		<div id="ReceiptHeader">
 			<div id="Logo">
-				{Logo(height: '100px')}
+				{Logo(height: '100')}
 			</div>
 			<div id="ReceiptTitle">
 				<h4>{ShopName}</h4>

--- a/pos-receipt.html
+++ b/pos-receipt.html
@@ -8,7 +8,7 @@
 	<body>
 		<div id="ReceiptHeader">
 			<div id="Logo">
-				{Logo}
+				{Logo(height: '100px')}
 			</div>
 			<div id="ReceiptTitle">
 				<h4>{ShopName}</h4>

--- a/receipt.html
+++ b/receipt.html
@@ -12,7 +12,7 @@
 
 	<div id="ReceiptHeader">
 		<div id="Logo">
-			{Logo}
+			{Logo(height: '100px')}
 		</div>
 		<div id="ReceiptTitle">
 			<h4>{ShopName}</h4>

--- a/receipt.html
+++ b/receipt.html
@@ -12,7 +12,7 @@
 
 	<div id="ReceiptHeader">
 		<div id="Logo">
-			{Logo(height: '100px')}
+			{Logo(height: '100')}
 		</div>
 		<div id="ReceiptTitle">
 			<h4>{ShopName}</h4>

--- a/returndocument.html
+++ b/returndocument.html
@@ -12,7 +12,7 @@
 
 	<div id="ReceiptHeader">
 		<div id="Logo">
-			{Logo}
+			{Logo(height: '100px')}
 		</div>
 		<div id="ReceiptTitle">
 			<h4>{%Ordernumber} {OrderNumber}</h4>

--- a/returndocument.html
+++ b/returndocument.html
@@ -12,7 +12,7 @@
 
 	<div id="ReceiptHeader">
 		<div id="Logo">
-			{Logo(height: '100px')}
+			{Logo(height: '100')}
 		</div>
 		<div id="ReceiptTitle">
 			<h4>{%Ordernumber} {OrderNumber}</h4>


### PR DESCRIPTION
Lisätty rajoitus logokuvan koolle, koska muisti loppuu jos on iso kuva logona. 

https://linear.app/mycashflow/issue/MCP-518/tutkintalappu-kasittelylistan-kuitin-tulostuksessa-loppuu-muisti