### PR TITLE
Adjust label-store margins and QR code size for better print alignment and scannability

### DIFF
--- a/labels/products/product-barcode-sticker-40x39mm.html
+++ b/labels/products/product-barcode-sticker-40x39mm.html
@@ -7,7 +7,7 @@
 	:root {
 		--page-width: 40mm;
 		--page-height: 39mm;
-		--page-margin: 2mm;
+		--page-margin: 3mm;
 	}
 
 	.TruncateName {

--- a/labels/products/storage-shelf-label-90x38mm.html
+++ b/labels/products/storage-shelf-label-90x38mm.html
@@ -7,7 +7,7 @@
 	:root {
 		--page-width: 90mm;
 		--page-height: 38mm;
-		--page-margin: 2mm;
+		--page-margin: 3mm;
 	}
 
 	.LeftSideSection {

--- a/labels/products/storage-shelf-label-90x38mm.html
+++ b/labels/products/storage-shelf-label-90x38mm.html
@@ -97,7 +97,7 @@
 							type: 'qr',
 							value: '{ShopUrl}/product/{ProductId}',
 							before: '<div class="Barcode"><img class="BarcodeQR" src="',
-							after: '" style="height: 1cm; width: 1cm; object-fit: contain;" /></div>'
+							after: '" style="height: 1.2cm; width: 1.2cm; object-fit: contain;" /></div>'
 						)}
 						{Text(
 							before: '<span style="max-width: 23ch;">',
@@ -111,7 +111,7 @@
 						type: 'ean',
 						value: '{VariationArticleNumber(or: '{ProductArticleNumber}')}',
 						before: '<div class="Barcode"><img class="BarcodeEAN" src="',
-						after: '" style="height: .5cm; object-fit: contain;" /></div>'
+						after: '" style="height: .7cm; object-fit: contain;" /></div>'
 					)}
 					<div class="BarcodeContent">{VariationArticleNumber(or: '{ProductArticleNumber}')}</div>
 				</div>

--- a/labels/products/store-shelf-label-90x38mm.html
+++ b/labels/products/store-shelf-label-90x38mm.html
@@ -7,7 +7,7 @@
 	:root {
 		--page-width: 90mm;
 		--page-height: 38mm;
-		--page-margin: 2mm;
+		--page-margin: 3mm;
 	}
 
 	.LeftSideSection {

--- a/labels/products/store-shelf-label-90x38mm.html
+++ b/labels/products/store-shelf-label-90x38mm.html
@@ -123,7 +123,7 @@
 							type: 'qr',
 							value: '{ShopUrl}/product/{ProductId}',
 							before: '<div class="Barcode"><img class="BarcodeQR" src="',
-							after: '" style="height: 1cm; width: 1cm; object-fit: contain;" /></div>'
+							after: '" style="height: 1.2cm; width: 1.2cm; object-fit: contain;" /></div>'
 						)}
 						{Text(
 							before: '<span style="max-width: 23ch;">',
@@ -185,7 +185,7 @@
 						type: 'ean',
 						value: '{VariationArticleNumber(or: '{ProductArticleNumber}')}',
 						before: '<div class="Barcode"><img class="BarcodeEAN" src="',
-						after: '" style="height: .5cm; object-fit: contain;" /></div>'
+						after: '" style="height: .7cm; object-fit: contain;" /></div>'
 					)}
 					<div class="BarcodeContent">{VariationArticleNumber(or: '{ProductArticleNumber}')}</div>
 				</div>


### PR DESCRIPTION
### Changes:

- Increased page margin from 2mm → 3mm for better alignment.
- Increased QR code size from 1cm → 1.2cm to enhance scannability.
- Increased barcode code height from 0.5 cm → 0.7 cm to enhance scannability.
