### PR TITLE
[MYC-2116] Add OrderCosts tag to default outputs

### DIFF
--- a/invoice.html
+++ b/invoice.html
@@ -96,13 +96,19 @@
 								<small>{OrderSubtotalTax}</small>
 							</td>
 						</tr>
-						{OrderShippingCosts(
-							before: '<tr class="CartTotal"><th scope="row" colspan="4">{%ShippingCosts}: {OrderShippingMethod}<br><small>{%VAT}&nbsp;{OrderShippingCostsTaxRate(after:'%')}</small></th><td class="CartTotal">',
-							after: '<br><small>{OrderShippingCostsTax}</small></td></tr>'
-						)}
-						{OrderPaymentCosts(
-							before: '<tr class="CartTotal"><th scope="row" colspan="4">{%PaymentCosts}: {OrderPaymentMethod(show_price: 'false')}<br><small>{%VAT}&nbsp;{OrderPaymentCostsTaxRate(after:'%')}</small></th><td class="CartTotal">',
-							after: '<br><small>{OrderPaymentCostsTax}</small></td></tr>'
+						{OrderCosts(
+							helper: '{{
+								<tr class="CartTotal">
+									<th scope="row" colspan="4">
+										{CostLabel}: {CostName}<br>
+										<small>{%VAT}&nbsp;{CostTaxRate(after:'%')}</small>
+									</th>
+									<td class="CartTotal">
+										{CostAmount}<br>
+										<small>{CostTax}</small>
+									</td>
+								</tr>
+							}}'
 						)}
 						{OrderDiscounts(
 							helper: '{{

--- a/pos-receipt.html
+++ b/pos-receipt.html
@@ -87,6 +87,20 @@
 									</tr>
 								}}'
 							)}
+							{OrderCosts(
+								helper: '{{
+									<tr class="CartTotal">
+										<th scope="row" colspan="3">
+											{CostLabel}: {CostName}<br />
+											<small>{%VAT}&nbsp;{CostTaxRate(after:'%')}</small>
+										</th>
+										<td class="CartTotal">
+											{CostAmount}<br />
+											<small>{CostTax}</small>
+										</td>
+									</tr>
+								}}'
+							)}
 							<tr class="CartTotal" id="FullTotal">
 								<th scope="row" colspan="3">
 									{%Total}<br />

--- a/receipt.html
+++ b/receipt.html
@@ -110,13 +110,19 @@
 								<small>{OrderSubtotalTax}</small>
 							</td>
 						</tr>
-						{OrderShippingCosts(
-							before: '<tr class="CartTotal"><th scope="row" colspan="4">{%ShippingCosts}: {OrderShippingMethod}<br><small>{%VAT}&nbsp;{OrderShippingCostsTaxRate(after:'%')}</small></th><td class="CartTotal">',
-							after: '<br><small>{OrderShippingCostsTax}</small></td></tr>'
-						)}
-						{OrderPaymentCosts(
-							before: '<tr class="CartTotal"><th scope="row" colspan="4">{%PaymentCosts}: {OrderPaymentMethod(show_price: 'false')}<br><small>{%VAT}&nbsp;{OrderPaymentCostsTaxRate(after:'%')}</small></th><td class="CartTotal">',
-							after: '<br><small>{OrderPaymentCostsTax}</small></td></tr>'
+						{OrderCosts(
+							helper: '{{
+								<tr class="CartTotal">
+									<th scope="row" colspan="4">
+										{CostLabel}: {CostName}<br>
+										<small>{%VAT}&nbsp;{CostTaxRate(after:'%')}</small>
+									</th>
+									<td class="CartTotal">
+										{CostAmount}<br>
+										<small>{CostTax}</small>
+									</td>
+								</tr>
+							}}'
 						)}
 						<tr class="CartTotal" id="FullTotal">
 							<th scope="row" colspan="4">{%Total} <br><small>{%VAT} {OrderTaxRate(after:'%')}</small></th>


### PR DESCRIPTION
| Q | A |
|:-----|:-----|
| Type | Feature |
| Related issue | [MYC-2116] |
| Contains deprecations | No |
| Backward compatible | Yes |
| Depends on | - |

- [ ] Dokumentaatio docs-hakemistossa on ajantasalla
- [x] Lisätty mergettäessä ohjelmistopäivitystiedotteeseen

### TL;DR

Replace bundled cost tags with OrderCosts tag in print templates to show shipping, payment, and return costs separately.

### Why was it done?

Customers couldn't see detailed cost breakdown on invoices/receipts. 

### What was done?

- Replaced {OrderShippingCosts} and {OrderPaymentCosts} with {OrderCosts} tag
- Updated 3 template files in public/themes/print/default/:
  - invoice.html
  - receipt.html
  - pos-receipt.html
- The {OrderCosts} tag displays each cost type (shipping, payment, return) as separate line items

### What can this change affect?

- Invoices/receipts will show more rows when orders have multiple cost types
- Improves transparency for customers, especially on returns

### Testing the change

Test scenarios:
1. Order with shipping + payment → Should show 2 separate cost rows
2. Order with return → Should show shipping, payment, and return costs separately
3. POS receipt → Cost breakdown now visible (previously only showed total)

### Automated tests

No new tests were added

### Other notes

None